### PR TITLE
Compatibility with Python 3.13 and modern versions of dependencies.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from pathlib import Path
 
 from rich import print
 from typer import Context
@@ -15,9 +15,24 @@ class App:
 def on_finished(_):
     print('Done! And here is your goodbye message.')
 
+# Create the outer shell.
+app = make_typer_shell(
+    prompt="🔥: ",
+    on_finished=on_finished,
+    obj=App(),
+    params={"name": "Bob"},
+    params_path=Path("params.yaml")
+)
 
-app = make_typer_shell(prompt="🔥: ", on_finished=on_finished, obj=App(), params={"name": "Bob"}, params_path="params.yaml")
-inner_app = make_typer_shell(prompt="🌲: ", on_finished=on_finished, params={"name": "Bob"}, params_path="innerparams.yaml")
+# Create an inner shell using a very similar call
+# to the factory function. This inner shell is only
+# accessible from the main shell.
+inner_app = make_typer_shell(
+    prompt="🌲: ",
+    on_finished=on_finished,
+    params={"name": "Bob"},
+    params_path=Path("innerparams.yaml")
+)
 app.add_typer(inner_app, name="inner")
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 markers = "sys_platform == \"darwin\""
 files = [
     {file = "appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c"},
@@ -19,7 +19,7 @@ version = "2.4.1"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24"},
     {file = "asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"},
@@ -38,7 +38,7 @@ version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
@@ -84,12 +84,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "python_console"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", python_console = "sys_platform == \"win32\""}
 
 [[package]]
 name = "decorator"
@@ -97,7 +97,7 @@ version = "5.1.1"
 description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.5"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
@@ -109,7 +109,7 @@ version = "2.0.1"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
 python-versions = ">=3.5"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
     {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
@@ -141,7 +141,7 @@ version = "8.12.3"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "ipython-8.12.3-py3-none-any.whl", hash = "sha256:b0340d46a933d27c657b211a329d0be23793c36595acf9e6ef4164bc01a1804c"},
     {file = "ipython-8.12.3.tar.gz", hash = "sha256:3910c4b54543c2ad73d06579aa771041b7d5707b033bd488669b4cf544e3b363"},
@@ -181,7 +181,7 @@ version = "0.19.1"
 description = "An autocompletion tool for Python that can be used for text editors."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
     {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
@@ -226,7 +226,7 @@ version = "0.1.7"
 description = "Inline Matplotlib backend for Jupyter"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
     {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
@@ -253,7 +253,7 @@ version = "0.8.4"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
     {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
@@ -269,7 +269,7 @@ version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 markers = "sys_platform != \"win32\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
@@ -285,7 +285,7 @@ version = "0.7.5"
 description = "Tiny 'shelve'-like database with concurrency support"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
@@ -297,7 +297,7 @@ version = "3.0.47"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
     {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
@@ -312,7 +312,7 @@ version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 markers = "sys_platform != \"win32\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -325,7 +325,7 @@ version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -340,7 +340,7 @@ version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "python_console"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
@@ -427,7 +427,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -450,7 +449,7 @@ version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -462,7 +461,7 @@ version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -495,7 +494,7 @@ version = "5.14.3"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
@@ -529,12 +528,12 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "python_console"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {dev = "python_version < \"3.10\""}
+markers = {dev = "python_version < \"3.10\"", python_console = "python_version < \"3.10\""}
 
 [[package]]
 name = "wcwidth"
@@ -542,7 +541,7 @@ version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "python_console"]
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
@@ -550,5 +549,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.8.1,<3.13"
-content-hash = "6e49e0270bbfd6138678f282e468682284583cdb362600be7e3c55ea2961332a"
+python-versions = ">=3.9.0"
+content-hash = "6b7cf596dbea5b2c2377ea98258ac3a854b7f0f1d35d7b7a77c31cc19a77aee2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,34 @@
-[tool.poetry]
+[project]
 name = "typer-shell"
 version = "0.2.0"
+requires-python  = ">=3.9.0"
 description = "A shell for typer apps with autocompletion and history"
-authors = ["fergus <fergusfettes@gmail.com>"]
+authors = [
+    {name= "Fergus Fettes", email="fergus <fergusfettes@gmail.com>"}
+]
 readme = "README.md"
+
+dependencies = [
+    "typer ~=0.16.0",
+    "click >=8.1.0",
+    "rich >=10.11.0",
+    "click_shell ~=2.1",
+    "pyyaml ~=6.0",
+]
+
+[tool.poetry]
 packages = [{include = "typer_shell"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.13"
-typer = "^0.16.0"
-click = "^8.1.3"
-rich = "^13.3.5"
-click-shell = "^2.1"
-pyyaml = "^6.0"
+# All are currently in [project.dependencies].
+
+# Use 'poetry install --with python_console'
+# to support the interactive Python debug console.
+[tool.poetry.group.python_console.dependencies]
+ipython = "*"
 
 [tool.poetry.group.dev.dependencies]
-ipdb = "^0.13.13"
+ipdb = ">=0.13.13,<0.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,3 @@
-click-shell==2.1 ; python_full_version >= "3.8.1" and python_version < "3.13"
-click==8.1.7 ; python_full_version >= "3.8.1" and python_version < "3.13"
-colorama==0.4.6 ; python_full_version >= "3.8.1" and python_version < "3.13" and platform_system == "Windows"
-markdown-it-py==3.0.0 ; python_full_version >= "3.8.1" and python_version < "3.13"
-mdurl==0.1.2 ; python_full_version >= "3.8.1" and python_version < "3.13"
-pygments==2.18.0 ; python_full_version >= "3.8.1" and python_version < "3.13"
-pyyaml==6.0.2 ; python_full_version >= "3.8.1" and python_version < "3.13"
-rich==13.8.0 ; python_full_version >= "3.8.1" and python_version < "3.13"
-shellingham==1.5.4 ; python_full_version >= "3.8.1" and python_version < "3.13"
-typer==0.12.5 ; python_full_version >= "3.8.1" and python_version < "3.13"
-typing-extensions==4.12.2 ; python_full_version >= "3.8.1" and python_version < "3.13"
+# File requirements.txt is not used here.
+# Dependencies are found in pyproject.toml.
+

--- a/typer_shell/typer_shell.py
+++ b/typer_shell/typer_shell.py
@@ -131,10 +131,13 @@ def _default(line: str):
     is help.
     """
     ctx = click.get_current_context()
-    default_cmd = (
-         ctx.command(ctx, "default")
-        or ctx.command(ctx, 'help')
-    )
+    if isinstance(ctx.command, click.Group):
+        default_cmd = (
+             ctx.command.get_command(ctx, "default")
+            or ctx.command.get_command(ctx, 'help')
+        )
+    else:
+        default_cmd = ctx.command
     if default_cmd.name == 'help':
         ctx.invoke(default_cmd, ctx=ctx, command=line)
     else:

--- a/typer_shell/typer_shell.py
+++ b/typer_shell/typer_shell.py
@@ -17,14 +17,14 @@ def make_typer_shell(
         on_finished: Callable = lambda ctx: None,
         intro: str = "\n Welcome to typer-shell! Type help to see commands.\n",
         obj: Optional[object] = None,
-        params: Optional[dict] = None,
+        params: Optional[dict[str,str]] = None,
         params_path: Optional[Path] = None,
         launch: Callable = lambda ctx: None,
-) -> None:
+) -> Typer:
     """Create a typer shell
         'default' is a default command to run if no command is found
         'obj' is an object to pass to the context
-        'params' is a boolean to add a local params command
+        'params' is dictionary of parameters to save in a YAML file
     """
     app = Typer()
 
@@ -58,7 +58,6 @@ def make_typer_shell(
         app.command(name="u", hidden=True)(update)
         app.command(name="print")(_print)
         app.command(name="p", hidden=True)(_print)
-
     return app
 
 
@@ -68,8 +67,8 @@ def _obj(
         params_path: Optional[Path] = None,
         obj: Optional[object] = None
 ):
-    # If there is an object and params, make sure the object has a field in the params dict for the shell
-    # If there is no object and params, make a fkae object for holding the dicts
+    # If there is an object and params, make sure the object has a field in the params dict for the shell.
+    # If there is no object and params, make a fake object for holding the dicts
     # If this is not the main shell and there is already an object from the main shell, print a warning
     if not obj and not params and not params_path:
         return
@@ -133,8 +132,8 @@ def _default(line: str):
     """
     ctx = click.get_current_context()
     default_cmd = (
-        ctx.command.get_command(ctx, "default")
-        or ctx.command.get_command(ctx, 'help')
+        ctx.command(ctx, "default")
+        or ctx.command(ctx, 'help')
     )
     if default_cmd.name == 'help':
         ctx.invoke(default_cmd, ctx=ctx, command=line)

--- a/typer_shell/typer_shell.py
+++ b/typer_shell/typer_shell.py
@@ -117,7 +117,11 @@ def help(ctx: Context, command: Annotated[Optional[str], Argument()] = None):
     if not command:
         ctx.parent.get_help()
         return
-    _command = ctx.parent.command(ctx, command)
+    # get_command() is only defined on Group
+    if isinstance(ctx.parent.command, click.Group):
+        _command = ctx.parent.command.get_command(ctx, command)
+    else:
+        _command = None
     if _command:
         _command.get_help(ctx)
     else:
@@ -131,6 +135,7 @@ def _default(line: str):
     is help.
     """
     ctx = click.get_current_context()
+    # get_command() is only defined on Group
     if isinstance(ctx.command, click.Group):
         default_cmd = (
              ctx.command.get_command(ctx, "default")

--- a/typer_shell/typer_shell.py
+++ b/typer_shell/typer_shell.py
@@ -117,7 +117,7 @@ def help(ctx: Context, command: Annotated[Optional[str], Argument()] = None):
     if not command:
         ctx.parent.get_help()
         return
-    _command = ctx.parent.command.get_command(ctx, command)
+    _command = ctx.parent.command(ctx, command)
     if _command:
         _command.get_help(ctx)
     else:
@@ -132,7 +132,7 @@ def _default(line: str):
     """
     ctx = click.get_current_context()
     default_cmd = (
-        ctx.command(ctx, "default")
+         ctx.command(ctx, "default")
         or ctx.command(ctx, 'help')
     )
     if default_cmd.name == 'help':

--- a/typer_shell/utils.py
+++ b/typer_shell/utils.py
@@ -5,7 +5,7 @@ from click import get_current_context
 
 
 def running_in_cli():
-    get_current_context(silent=True) is not None
+    return get_current_context(silent=True) is not None
 
 
 class IO:
@@ -20,7 +20,7 @@ class IO:
             prompt = click.get_text_stream("stdin").read().strip()
             click.echo("Generating...", err=True)
             if not prompt:
-                click.echo("No prompt provided. Use the -p flag or pipe a prompt to stdin.", err=True, color="red")
+                click.echo("No prompt provided. Use the -p flag or pipe a prompt to stdin.", err=True, color=True)
                 raise click.Abort()
         return prompt
 


### PR DESCRIPTION
- **ADDED:** Compatible with Python 3.13. This required updating Typer, Click, click-shell, and other dependencies to versions that support Python 3.13. This is a BREAKING CHANGE for projects that are tied to older versions of those dependencies, because some of the libraries' API signatures changed.
- **ADDED:** More complete project definition in pyproject.toml to take better advantage of Poetry and other build tools. requirements.txt is now only comments, with all dependencies declared in pyproject.toml.
- **DROPPED:** Dropped support for Python 3.8.x which is [officially EOL](https://devguide.python.org/versions/).
- **FIXED:** make_typer_shell() was returning None but was expected by callers to return the Typer instance.
- **FIXED:** Incorrect typing of some variables and function parameters.
- **EDITED:** Corrected some typos in comments and string literals. Formatted some one-line function calls to multi-line to match the style of the rest of the code and to make demo.py more approachable for newcomers.
- **KNOWN ISSUE:** The "magic rainbow" panel is not working.

I am submitting this PR as a draft for comment and early review and in hope that other eyes will spot the problem with the "magic rainbow" panel.